### PR TITLE
Rewrote for easier benchmark suite composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /.lein-failures
 /.classpath
 /.settings
+.lein-repl-history
+.nrepl-port

--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :dev-dependencies [[lein-expectations "0.0.8"]
                      [expectations "1.4.41"]]
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [net.mikera/core.matrix "0.15.0"]
-                 [net.mikera/core.matrix.stats "0.3.0"]
-                 [net.mikera/vectorz-clj "0.16.1-SNAPSHOT"]
-                 [clatrix "0.4.0-SNAPSHOT"]]
-  :profiles {:dev {:dependencies [[criterium/criterium "0.4.1"]
-                                  [expectations "1.4.41"]]}})
+                 [net.mikera/core.matrix "0.36.1"]
+                 [net.mikera/core.matrix.stats "0.6.0"]
+                 [net.mikera/vectorz-clj "0.30.1"]
+                 [clatrix "0.5.0"]]
+  :profiles {:dev {:dependencies [[criterium/criterium "0.4.3"]
+                                  [expectations "2.1.1"]]}})

--- a/src/clojure/core/matrix/benchmark.clj
+++ b/src/clojure/core/matrix/benchmark.clj
@@ -1,6 +1,7 @@
 (ns clojure.core.matrix.benchmark
   (:use clojure.repl)
-  (:use clojure.core.matrix)
+  ;; Don't like :refer :all ; should swap out, but for now to get running
+  (:require [clojure.core.matrix :as mat :refer :all])
   (:use clojure.core.matrix.stats)
   (:require [clojure.core.matrix.operators])
   (:require [clojure.core.matrix.protocols :as mp])
@@ -10,50 +11,149 @@
   (:require [mikera.vectorz.matrix :as m])
   (:import [mikera.vectorz Vector3 Vectorz]))
 
-(defmacro bench [exp]
+
+;; Some benchmarking macros
+
+(defmacro bench-expr [exp]
+  "Simply benchmark an expression and return the mean in secs"
   `(let [res# (c/quick-benchmark ~exp nil)]
-     (* 1000000000 (first (:mean res#)))))
+     (first (:mean res#))))
+
+(defn m-op-bench [m operation arity]
+  "Takes a matrix, an operation fn, and an arity of the function, and benchmarks
+  `(operation m m m...)` with m inserted `arity` times."
+  (case arity
+    1 (bench-expr (operation m))
+    2 (bench-expr (operation m m))))
+
+
+;; Matrix and vector generators
+
+(defn setup-rand-matrix
+  ([impl generator n m]
+   (reduce
+     (fn [mat [i j]] (mat/mset mat i j (generator)))
+     (mat/new-matrix impl n m)
+     (for [i (range n)
+           j (range m)]
+       [i j])))
+  ([impl generator n]
+   (setup-rand-matrix impl generator n n)))
+
+(defn setup-rand-vector
+  [impl generator n]
+  (reduce
+    (fn [v i] (mat/mset v i (generator)))
+    (mat/new-vector impl n)
+    (range n)))
+
+;; A default/simple int generator...
+(def int-gen (partial rand-int 10))
+
+
+;; ## Benchmarks
+;;
+;; Here we construct a catalog of various benchmarks, which then become available in the functions below
+
+(def benchmarks
+  {:mmul          {:fn      mat/mmul
+                   :arity   2}
+   :mul           {:fn      mat/mul
+                   :arity   2}
+   :mul!          {:fn      mat/mul!
+                   :arity   2
+                   :mutable true}
+   :inverse       {:fn      mat/inverse
+                   :arity   1}
+   :matrix/add    {:fn      mat/add
+                   :arity   2}
+   :matrix/add!   {:fn      mat/add!
+                   :arity   2
+                   :mutable true}
+   ;; Vector benchmarks
+   :normalise!    {:fn      mat/normalise!
+                   :arity   1
+                   :mutable true
+                   :types   :vector}
+   :normalise     {:fn      mat/normalise
+                   :arity   1
+                   :types   :vector}
+   :inner-product {:fn      mat/inner-product
+                   :arity   2
+                   :types   :vector}
+   :vector/add    {:fn      mat/add
+                   :arity   2
+                   :types   :vector}
+   :vector/add!   {:fn      mat/add!
+                   :arity   2
+                   :types   :vector
+                   :mutable true}})
+
+
+(defn bench
+  "Runs a benchmark for the given operation, given an implementation and a dimension"
+  [operation-key impl dimension]
+  (let [{f :fn arity :arity types :types :as op}
+             (get benchmarks operation-key)
+        morv (if (= :vector types)
+               (setup-rand-vector impl int-gen dimension)
+               (setup-rand-matrix impl int-gen dimension))
+        ;; Hmm... letting the data type be mutable makes this take a lot longer. But then leaving it out, the
+        ;; operation still works and is much faster. What's going on here?
+        ;morv (if (:mutable op)
+               ;(mat/mutable morv)
+               ;morv)]
+               ]
+    (m-op-bench morv f arity)))
+
+
+(defn benches
+  "For each of the operations, impls, dimensions, does the given benchmark, and returns a map with
+  keys `[:operation :implementation :dimension :bench]`. Note this function is lazy, so it's recommended
+  you use `doall` if you want things computed greedily..."
+  [operations impls dimensions]
+  (for [operation operations
+        impl      impls
+        dimension dimensions]
+    {:operation      operation
+     :implementation impl
+     :dimension      dimension
+     :bench          (bench operation impl dimension)}))
+
+
+(defn- row-printer
+  [row]
+  (println (clojure.string/join \tab row)))
+
+
+(defn report-benches
+  "Like benches, but prints output to stdout"
+  [benches]
+  (row-printer ["Operation" "Implementation" "Dimension" "Time (ns)"])
+  (doseq [row benches]
+    (row-printer (map row [:operation :implementation :dimension :bench]))))
+
 
 (def sizes (vec (concat [1 2 3 4 5 6 7 8 10 13] (map #(long (* 16 (pow 2.0 (/ % 3)))) (range 22))))) 
-(def pot-sizes (vec (map #(long (pow 2.0 %)) (range 21)))) 
+(def pot-sizes (mapv #(long (pow 2.0 %)) (range 21)))
+
 
 (defn benchmarks []
+  ;; benchmark for mutable vs immutable operations
+  ;; mutable operation
+  ;; 72ns
+  (bench :vector/add! :clatrix 100)
+  (bench :vector/add! :vectorz 100)
 
-  (set-current-implementation :vectorz)
-  (set-current-implementation :clatrix)
+   ;; immutable operation
+  ;; 320ns
+  (bench :vector/add :clatrix 100)
+  (bench :vector/add :vectorz 100)
 
-;; benchmark for mutable vs immutable operations
-  ;; mutable operation
- ;; 72ns
- (let [a (array (range 100))
-        b (array (range 100))]
-    (c/quick-bench
-      (add! a b)))
-  
-  ;; immutable operation
- ;; 320ns
- (let [a (array (range 100))
-        b (array (range 100))]
-    (c/quick-bench
-      (add a b)))  
-  
- (defn matrix-bench [impl sizes]
-   (doseq [n sizes]
-      (let [m (zero-matrix impl n n)]
-        (println (str n \tab (bench (mmul m m)))))))
- 
- (matrix-bench :vectorz sizes)
- (matrix-bench :clatrix sizes)
-  
- (defn vector-bench [impl sizes]
-   (doseq [n sizes]
-      (let [a (zero-vector impl n)
-           b (zero-vector impl n)]
-        (assign! a (vec (range n)))
-       (assign! b (vec (range n)))
-        (println (str n \tab (bench (add a b)))))))
+  (doseq [b (benches [:mmul] [:vectorz :clatrix] sizes)]
+    (println (str "mmul size" (:dimension b) ":" \tab (:bench b))))
 
- (vector-bench :vectorz pot-sizes)
- (vector-bench :clatrix pot-sizes)
-  
-)
+  (doseq [b (benches [:vector/add] [:vectorz :clatrix] pot-sizes)]
+    (println (str "vector/add size" (:dimension b) ":" \tab (:bench b)))))
+
+


### PR DESCRIPTION
The idea is to create a catalog of functions we can benchmark, with some machinery for how to run those benchmarks. The goal is to write something that looks like:

``` clojure
(doall (benches [:mmul :mmul!] [:vectorz :clatrix] [5 10 20 50 100]))
```

That would run a benchmarks for each `(operation, implementation, dimension)` triple. Have ideas for machinery that could be built up around that, but this is all the time I can spare for now.
